### PR TITLE
Add non-invasive configuration validation checks

### DIFF
--- a/app/core/non_invasive_monitor.py
+++ b/app/core/non_invasive_monitor.py
@@ -53,6 +53,12 @@ class SystemStatus:
     firewall_status: str
     last_activity: datetime | None
     cache_valid: bool
+    rkhunter_config_ok: bool = False
+    rkhunter_config_details: str = ""
+    clamav_config_ok: bool = False
+    clamav_config_details: str = ""
+    ufw_config_ok: bool = False
+    ufw_config_details: str = ""
 
 
 class NonInvasiveSystemMonitor:
@@ -165,9 +171,11 @@ class NonInvasiveSystemMonitor:
         """Collect fresh system status using only non-invasive methods"""
         # RKHunter status (non-invasive)
         rkhunter_available, rkhunter_version = self._check_rkhunter_non_invasive()
+        rkhunter_config_ok, rkhunter_config_details = self._validate_rkhunter_configuration()
 
         # ClamAV status (non-invasive)
         clamav_available, clamav_version = self._check_clamav_non_invasive()
+        clamav_config_ok, clamav_config_details = self._validate_clamav_configuration()
 
         # Virus definitions age (non-invasive)
         virus_def_age = self._check_virus_definitions_age()
@@ -177,6 +185,7 @@ class NonInvasiveSystemMonitor:
 
         # Firewall status (using existing non-invasive method)
         firewall_status = self._get_firewall_status_non_invasive()
+        ufw_config_ok, ufw_config_details = self._validate_ufw_configuration()
 
         return SystemStatus(
             timestamp=datetime.now(),
@@ -189,6 +198,12 @@ class NonInvasiveSystemMonitor:
             firewall_status=firewall_status,
             last_activity=datetime.now(),
             cache_valid=True,
+            rkhunter_config_ok=rkhunter_config_ok,
+            rkhunter_config_details=rkhunter_config_details,
+            clamav_config_ok=clamav_config_ok,
+            clamav_config_details=clamav_config_details,
+            ufw_config_ok=ufw_config_ok,
+            ufw_config_details=ufw_config_details,
         )
 
     def _check_rkhunter_non_invasive(self) -> tuple[bool, str]:
@@ -390,6 +405,122 @@ class NonInvasiveSystemMonitor:
             print(f"⚠️ Error checking firewall: {e}")
             return f"error: {e!s}"
 
+    def _validate_rkhunter_configuration(self) -> tuple[bool, str]:
+        """Validate RKHunter configuration using lightweight checks."""
+        issues: list[str] = []
+
+        config_paths = [
+            "/etc/rkhunter.conf",
+            "/usr/local/etc/rkhunter.conf",
+            str(Path.home() / ".config" / "search-and-destroy" / "rkhunter.conf"),
+        ]
+
+        config_readable = False
+        for config_path in config_paths:
+            if os.path.exists(config_path):
+                if os.access(config_path, os.R_OK):
+                    config_readable = True
+                    break
+                issues.append(f"Config not readable: {config_path}")
+        if not config_readable:
+            issues.append("No readable RKHunter configuration found")
+
+        db_locations = [
+            "/var/lib/rkhunter/db",
+            "/usr/local/var/lib/rkhunter/db",
+            str(Path.home() / ".rkhunter" / "db"),
+        ]
+
+        db_ok = False
+        for db_path in db_locations:
+            if os.path.isdir(db_path):
+                try:
+                    if any(Path(db_path).iterdir()):
+                        db_ok = True
+                        break
+                except OSError:
+                    continue
+        if not db_ok:
+            issues.append("RKHunter database not found")
+
+        if issues:
+            return False, "; ".join(issues)
+        return True, "Configuration healthy"
+
+    def _validate_clamav_configuration(self) -> tuple[bool, str]:
+        """Validate ClamAV configuration efficiently without elevation."""
+        issues: list[str] = []
+
+        config_candidates = [
+            "/etc/clamav/clamd.conf",
+            "/etc/clamd.conf",
+            "/usr/local/etc/clamd.conf",
+        ]
+
+        config_present = False
+        for config_path in config_candidates:
+            if os.path.exists(config_path):
+                config_present = True
+                if not os.access(config_path, os.R_OK):
+                    issues.append(f"Config not readable: {config_path}")
+                break
+        if not config_present:
+            issues.append("ClamAV config missing")
+
+        database_paths = [
+            "/var/lib/clamav",
+            "/usr/share/clamav",
+            "/app/share/clamav",
+        ]
+
+        db_files = [
+            "main.cvd",
+            "main.cld",
+            "daily.cvd",
+            "daily.cld",
+        ]
+
+        db_found = False
+        for db_dir in database_paths:
+            if os.path.isdir(db_dir):
+                for db_file in db_files:
+                    if os.path.exists(os.path.join(db_dir, db_file)):
+                        db_found = True
+                        break
+            if db_found:
+                break
+        if not db_found:
+            issues.append("Virus definition database missing")
+
+        if issues:
+            return False, "; ".join(issues)
+        return True, "Configuration healthy"
+
+    def _validate_ufw_configuration(self) -> tuple[bool, str]:
+        """Validate UFW configuration using file checks instead of commands."""
+        issues: list[str] = []
+
+        config_path = "/etc/ufw/ufw.conf"
+        if os.path.exists(config_path):
+            try:
+                with open(config_path, encoding="utf-8") as f:
+                    config_content = f.read()
+                if "ENABLED=yes" not in config_content and "ENABLED=no" not in config_content:
+                    issues.append("UFW config missing ENABLED flag")
+            except (OSError, UnicodeDecodeError) as exc:
+                issues.append(f"Unable to read UFW config: {exc}")
+        else:
+            issues.append("UFW config missing")
+
+        rules_paths = ["/var/lib/ufw/user.rules", "/var/lib/ufw/user6.rules"]
+        rules_present = any(os.path.exists(path) and os.path.getsize(path) > 0 for path in rules_paths)
+        if not rules_present:
+            issues.append("No UFW rule files detected")
+
+        if issues:
+            return False, "; ".join(issues)
+        return True, "Configuration healthy"
+
     def record_user_activity(self, activity_type: str, details: str = "") -> None:
         """Record user activity to improve status caching"""
         with self._lock:
@@ -425,9 +556,18 @@ if __name__ == "__main__":
     print("\n📊 SYSTEM STATUS REPORT:")
     print(f"Timestamp: {status.timestamp}")
     print(f"RKHunter: {'✅' if status.rkhunter_available else '❌'} {status.rkhunter_version}")
+    print(
+        f"RKHunter config: {'✅' if status.rkhunter_config_ok else '❌'} {status.rkhunter_config_details}"
+    )
     print(f"ClamAV: {'✅' if status.clamav_available else '❌'} {status.clamav_version}")
+    print(
+        f"ClamAV config: {'✅' if status.clamav_config_ok else '❌'} {status.clamav_config_details}"
+    )
     print(f"Virus Definitions Age: {status.virus_definitions_age} days")
     print(f"Firewall: {status.firewall_status}")
+    print(
+        f"UFW config: {'✅' if status.ufw_config_ok else '❌'} {status.ufw_config_details}"
+    )
     print("System Services:")
     for service, state in status.system_services.items():
         print(f"  {service}: {state}")


### PR DESCRIPTION
## Summary
- extend the system status dataclass to track configuration health for RKHunter, ClamAV, and UFW
- add non-invasive configuration validation methods using file-based checks for each security tool
- include configuration details in the non-invasive monitor’s test output for quick verification

## Testing
- python -m compileall app/core/non_invasive_monitor.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a441571ac8321aacebe2886e07e4b)