### PR TITLE
Add Flatpak build support targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 # xanadOS Search & Destroy - Modern Development Makefile
 # Enhanced with 2025 best practices and modern tooling
 
-.PHONY: help setup install-deps validate test check-env run run-debug dev clean lint format
+.PHONY: help setup install-deps validate test check-env run run-debug dev clean lint format \
+        build-flatpak install-flatpak run-flatpak prepare
 
 # Default goal
 .DEFAULT_GOAL := help
@@ -217,7 +218,31 @@ lint: ## Run code quality checks
 format: ## Format code with ruff
 	@echo -e "$(BOLD)$(GREEN)🧪 Formatting code...$(NC)"
 	@if [ -d ".venv" ]; then \
-		source .venv/bin/activate && python -m ruff format . || true; \
+	source .venv/bin/activate && python -m ruff format . || true; \
 	else \
-		echo -e "$(YELLOW)⚠️  Virtual environment not found. Install with 'make setup'$(NC)"; \
+	echo -e "$(YELLOW)⚠️  Virtual environment not found. Install with 'make setup'$(NC)"; \
 	fi
+
+FLATPAK_ID := io.github.asafelobotomy.SearchAndDestroy
+FLATPAK_MANIFEST := packaging/flatpak/$(FLATPAK_ID).yml
+FLATPAK_BUILD_DIR := build/flatpak/app
+
+prepare: ## Prepare local environment for Flatpak builds
+	@echo -e "$(BOLD)$(CYAN)🛠️  Preparing Flatpak build environment...$(NC)"
+	@bash scripts/prepare-build.sh
+
+build-flatpak: ## Build Flatpak package
+	@echo -e "$(BOLD)$(GREEN)📦 Building Flatpak package...$(NC)"
+	@bash scripts/prepare-build.sh
+	@flatpak-builder --force-clean $(FLATPAK_BUILD_DIR) $(FLATPAK_MANIFEST)
+	@echo -e "$(GREEN)✅ Flatpak build complete$(NC)"
+
+install-flatpak: ## Build and install Flatpak locally (user scope)
+	@echo -e "$(BOLD)$(GREEN)📦 Installing Flatpak locally...$(NC)"
+	@bash scripts/prepare-build.sh
+	@flatpak-builder --user --install --force-clean $(FLATPAK_BUILD_DIR) $(FLATPAK_MANIFEST)
+	@echo -e "$(GREEN)✅ Flatpak installed in user scope$(NC)"
+
+run-flatpak: ## Run the installed Flatpak application
+	@echo -e "$(BOLD)$(GREEN)🚀 Running Flatpak application...$(NC)"
+	@flatpak run $(FLATPAK_ID)

--- a/scripts/prepare-build.sh
+++ b/scripts/prepare-build.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Prepare local environment for Flatpak builds
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+FLATPAK_ID="io.github.asafelobotomy.SearchAndDestroy"
+MANIFEST_PATH="${REPO_ROOT}/packaging/flatpak/${FLATPAK_ID}.yml"
+BUILD_DIR="${REPO_ROOT}/build/flatpak"
+
+print_section() {
+    echo -e "\n\033[1;36m➡️  $1\033[0m"
+}
+
+require_cmd() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo -e "\033[0;31m❌ Missing dependency: $1\033[0m" >&2
+        echo "Install it and re-run this script." >&2
+        exit 1
+    fi
+    echo -e "\033[0;32m✅ $1 found\033[0m"
+}
+
+print_section "Checking required commands"
+require_cmd flatpak
+require_cmd flatpak-builder
+
+print_section "Ensuring Flathub remote is configured"
+if flatpak remote-list | grep -q "^flathub"; then
+    echo -e "\033[0;32m✅ Flathub remote already present\033[0m"
+else
+    flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+    echo -e "\033[0;32m✅ Flathub remote added\033[0m"
+fi
+
+print_section "Validating Flatpak manifest"
+if [ -f "${MANIFEST_PATH}" ]; then
+    echo -e "\033[0;32m✅ Manifest found at ${MANIFEST_PATH}\033[0m"
+else
+    echo -e "\033[0;31m❌ Manifest not found at ${MANIFEST_PATH}\033[0m" >&2
+    exit 1
+fi
+
+print_section "Preparing build directories"
+mkdir -p "${BUILD_DIR}"
+echo -e "\033[0;32m✅ Build directory ready at ${BUILD_DIR}\033[0m"
+
+echo -e "\n\033[1;32m🎉 Environment is ready for Flatpak builds!\033[0m"


### PR DESCRIPTION
## Summary
- add a Flatpak build preparation script to check dependencies and ensure the manifest/build directories exist
- expose Flatpak build, install, run, and preparation targets in the Makefile using the existing Flatpak manifest

## Testing
- make help


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a450556dc8321a6f9b1baa4ca1ae9)