### PR TITLE
Improve Flatpak manifest for local builds

### DIFF
--- a/packaging/flatpak/io.github.asafelobotomy.SearchAndDestroy.yml
+++ b/packaging/flatpak/io.github.asafelobotomy.SearchAndDestroy.yml
@@ -82,17 +82,22 @@ modules:
 
   - name: python-dependencies
     buildsystem: simple
+    build-options:
+      env:
+        PIP_DISABLE_PIP_VERSION_CHECK: '1'
+        PIP_NO_CACHE_DIR: '1'
     build-commands:
-      - echo "Using PyQt BaseApp - no additional Python packages needed"
-    sources: []
+      - pip3 install --verbose --exists-action=i --no-build-isolation --find-links="file://${PWD}/packaging/flatpak/vendor" --prefix=${FLATPAK_DEST} -r packaging/flatpak/requirements-base.txt
+    sources:
+      - type: dir
+        path: ../..
 
   - name: search-and-destroy
     buildsystem: simple
     build-commands:
       - install -Dm755 packaging/flatpak/search-and-destroy.sh /app/bin/search-and-destroy
       - cp -r app/ /app/lib/search-and-destroy/
-      - install -Dm644 app.desktop /app/share/applications/io.github.asafelobotomy.SearchAndDestroy.desktop
-      - sed -i 's/Exec=search-and-destroy/Exec=python3 \/app\/lib\/search-and-destroy\/main.py/' /app/share/applications/io.github.asafelobotomy.SearchAndDestroy.desktop
+      - install -Dm644 packaging/flatpak/io.github.asafelobotomy.SearchAndDestroy.desktop /app/share/applications/io.github.asafelobotomy.SearchAndDestroy.desktop
       - install -Dm644 packaging/flatpak/io.github.asafelobotomy.SearchAndDestroy.metainfo.xml /app/share/metainfo/io.github.asafelobotomy.SearchAndDestroy.metainfo.xml
       # Install icons
       - install -Dm644 packaging/icons/io.github.asafelobotomy.SearchAndDestroy.svg /app/share/icons/hicolor/scalable/apps/io.github.asafelobotomy.SearchAndDestroy.svg
@@ -102,7 +107,11 @@ modules:
               install -Dm644 "packaging/icons/io.github.asafelobotomy.SearchAndDestroy-${size}.png" "/app/share/icons/hicolor/${size}x${size}/apps/io.github.asafelobotomy.SearchAndDestroy.png"
             fi
           done
+      # Ship default configuration and build metadata
+      - install -d /app/share/search-and-destroy/config
+      - cp -r config/*.toml /app/share/search-and-destroy/config/ 2>/dev/null || true
+      - cp -r config/*.json /app/share/search-and-destroy/config/ 2>/dev/null || true
+      - if [ -f VERSION ]; then install -Dm644 VERSION /app/share/search-and-destroy/VERSION; fi
     sources:
-      - type: git
-        url: https://github.com/asafelobotomy/xanadOS-Search_Destroy.git
-        commit: b385e3aad80b9acd544aea0cfe8955cd132a91bd
+      - type: dir
+        path: ../..


### PR DESCRIPTION
## Summary
- switch the Flatpak manifest to consume the local source tree instead of the pinned remote commit
- install runtime Python requirements during the Flatpak build and bundle default configuration/metadata
- fix the desktop entry installation to use the tracked file and remove the Exec rewrite

## Testing
- not run (flatpak/flatpak-builder unavailable in the environment; apt repos return 403)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a46d876c48321aa9aad3e195c6c7c)