### PR TITLE
Align Flatpak manifests with KDE BaseApp runtime

### DIFF
--- a/packaging/flatpak/README.md
+++ b/packaging/flatpak/README.md
@@ -1,8 +1,8 @@
 # Flatpak packaging
 
-- Manifest: `io.GitHub.asafelobotomy.SearchAndDestroy.yml`
-- Desktop file: `io.GitHub.asafelobotomy.SearchAndDestroy.desktop`
-- Metainfo: `io.GitHub.asafelobotomy.SearchAndDestroy.metainfo.XML`
-- Icons: `../icons/io.GitHub.asafelobotomy.SearchAndDestroy.*`
+- Manifest: `io.github.asafelobotomy.SearchAndDestroy.yml`
+- Desktop file: `io.github.asafelobotomy.SearchAndDestroy.desktop`
+- Metainfo: `io.github.asafelobotomy.SearchAndDestroy.metainfo.xml`
+- Icons: `../icons/io.github.asafelobotomy.SearchAndDestroy.*`
 
 Follow Flathub guidelines: [Flathub Requirements](HTTPS://docs.flathub.org/docs/for-app-authors/requirements)

--- a/packaging/flatpak/io.github.asafelobotomy.SearchAndDestroy-optimized.yml
+++ b/packaging/flatpak/io.github.asafelobotomy.SearchAndDestroy-optimized.yml
@@ -1,7 +1,7 @@
 app-id: io.github.asafelobotomy.SearchAndDestroy
-runtime: org.freedesktop.Platform
-runtime-version: "23.08"
-sdk: org.freedesktop.Sdk
+runtime: org.kde.Platform
+runtime-version: "6.8"
+sdk: org.kde.Sdk
 base: com.riverbankcomputing.PyQt.BaseApp
 base-version: "6.8"
 command: search-and-destroy

--- a/packaging/flatpak/io.github.asafelobotomy.SearchAndDestroy.yml
+++ b/packaging/flatpak/io.github.asafelobotomy.SearchAndDestroy.yml
@@ -1,7 +1,7 @@
 app-id: io.github.asafelobotomy.SearchAndDestroy
-runtime: org.freedesktop.Platform
-runtime-version: "23.08"
-sdk: org.freedesktop.Sdk
+runtime: org.kde.Platform
+runtime-version: "6.8"
+sdk: org.kde.Sdk
 base: com.riverbankcomputing.PyQt.BaseApp
 base-version: "6.8"
 command: search-and-destroy


### PR DESCRIPTION
## Summary
- update Flatpak manifests to use the KDE 6.8 runtime and SDK that match the PyQt BaseApp base
- correct Flatpak packaging README references to match actual lowercase file names

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a4805ee108321a38ba9ae7f5fa742)